### PR TITLE
add matomo track link option for download tracking refs #120405

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -57,3 +57,10 @@ export const trackSiteSearch = (options) => {
     m.trackSiteSearch(options);
   });
 };
+
+export const trackLink = (options) => {
+  doWithMatomo((m) => {
+    m.trackLink(options);
+  });
+};
+


### PR DESCRIPTION
To be merged together with forests-frontend PR with the same branch-name and volto-datablocks PR with the same branch-name.