### PR TITLE
Added the pushInstruction() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,12 @@ or `RAZZLE_MATOMO_SITE_ID` and `RAZZLE_MATOMO_URL` environment variables.
 
 ## API
 
-There are two exports in `utils.js` (which can be imported from `volto-matomo/utils`, including from other Volto addons):
+There are four exports in `utils.js` (which can be imported from `volto-matomo/utils`, including from other Volto addons):
 
 1. `trackPageView({ href, ...options }) : void` - takes an object with `href` and other options and sends to Matomo a page view track;
 2. `trackEvent(options) : void` - takes an `options` object parameter and sends to Matomo an event track.
-2. `trackSiteSearch(options) : void` - takes an `options` object parameter and sends to Matomo an site search track.
+3. `trackSiteSearch(options) : void` - takes an `options` object parameter and sends to Matomo an site search track.
+4. `pushInstruction(name, ...args): void` - takes a name and an arbitrary number of parameters, and pushes them to Matomo.
 
 Note that the Matomo instance is behind the scenes lazy-loaded and cached.
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -63,3 +63,9 @@ export const trackLink = (options) => {
     m.trackLink(options);
   });
 };
+
+export const pushInstruction = (name, ...args) => {
+  doWithMatomo((m) => {
+    m.pushInstruction(name, ...args);
+  });
+};


### PR DESCRIPTION
We have added the `pushInstruction('key', ...args)` function in the utils.js file, as it was the only one missing,  to set custom settings to the Matomo instance.

This function can be used to pass additional features to Matomo.

The [signature of pushInstruction is in the base code](https://github.com/Amsterdam/matomo-tracker/blob/f85b6179e58e77dfc048573817fa8de43873a669/packages/js/src/MatomoTracker.ts#L353) of matomo-tracker and allows passing arbitrary number of arguments.

```JS
import { pushInstruction } from '@eeacms/volto-matomo/utils';

// Example with multiple parameters
pushInstruction('setCustomDimension', 1, 'Hello world!');

// Example with one parameter
pushInstruction('setUserId', 'user_id');
```
