### PR TITLE
Second matomo in parallel - refs #249086

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ To configure it, either set the following variables:
 
 or `RAZZLE_MATOMO_SITE_ID` and `RAZZLE_MATOMO_URL` environment variables.
 
+With version 4.0.0+, you have the possibility to use a second matomo in parallel:
+
+- `settings.matomoSecondSiteId` (if not available it uses: `1`)
+- `settings.matomoSecondUrlBase` (if not available it uses: `https://matomo.eea.europa.eu/`)
+
+or `RAZZLE_MATOMO_SECOND_SITE_ID` and `RAZZLE_MATOMO_SECOND_URL` environment variables.
+
 ## API
 
 There are four exports in `utils.js` (which can be imported from `volto-matomo/utils`, including from other Volto addons):
@@ -58,7 +65,7 @@ The default behavior of volto-matomo is a call to `trackPageView` in `utils.js`,
    ],
 
    "dependencies": {
-       "@eeacms/volto-matomo": "1.0.0"
+       "@eeacms/volto-matomo": "4.0.0"
    }
    ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eeacms/volto-matomo",
-  "version": "3.0.1",
+  "version": "4.0.0",
   "description": "volto-matomo: Volto add-on",
   "main": "src/index.js",
   "author": "European Environment Agency: IDM2 A-Team",

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,7 +11,7 @@ const _matomo = {};
 
 const doWithMatomo = (fn) => {
   if (__SERVER__) return;
-  if (!_matomo.instance) {
+  if (!(_matomo.instance1 || _matomo.instance2)) {
     const siteId =
       window.env?.RAZZLE_MATOMO_SITE_ID || config.settings.matomoSiteId;
 
@@ -24,7 +24,7 @@ const doWithMatomo = (fn) => {
       window.env?.RAZZLE_MATOMO_USER_ID || config.settings.matomoUserId;
 
     const trackerUrl =
-      window.env?.RAZZLE_MATOMO_TRAKER_URL ||
+      window.env?.RAZZLE_MATOMO_TRACKER_URL ||
       config.settings.matomoTrackerUrl ||
       `${urlBase}matomo.php`;
 
@@ -33,12 +33,46 @@ const doWithMatomo = (fn) => {
       config.settings.matomoSrcUrl ||
       `${urlBase}matomo.js`;
 
+    const secondSiteId =
+      window.env?.RAZZLE_MATOMO_SECOND_SITE_ID ||
+      config.settings.matomoSecondSiteId;
+
+    const secondUrlBase =
+      window.env?.RAZZLE_SECOND_MATOMO_URL ||
+      config.settings.matomoSecondUrlBase ||
+      urlBase;
+
+    const secondUserId =
+      window.env?.RAZZLE_MATOMO_SECOND_USER_ID ||
+      config.settings.matomoSecondUserId ||
+      userId;
+
+    const secondTrackerUrl =
+      window.env?.RAZZLE_MATOMO_SECOND_TRACKER_URL ||
+      config.settings.matomoSecondTrackerUrl ||
+      trackerUrl;
+
+    const secondSrcUrl =
+      window.env?.RAZZLE_MATOMO_SECOND_SRC_URL ||
+      config.settings.matomoSecondSrcUrl ||
+      srcUrl;
+
+    if (!(siteId || secondSiteId)) {
+      if (window.console) {
+        /* eslint-disable-next-line */
+        console.warn(
+          'Matomo SiteID is not defined, page actions will not be tracked',
+        );
+      }
+      return;
+    }
+
     if (siteId) {
       /**
        * NOTE: check this link to see all the available options
        * https://www.npmjs.com/package/@datapunt/matomo-tracker-react
        */
-      _matomo.instance = createInstance({
+      _matomo.instance1 = createInstance({
         urlBase,
         siteId,
         userId,
@@ -47,15 +81,27 @@ const doWithMatomo = (fn) => {
         // Add your own configuration
         ...(config.settings.matomo || {}),
       });
-    } else {
-      /* eslint-disable-next-line */
-      console.warn(
-        'Matomo SiteID is not defined, page actions will not be tracked',
-      );
+    }
+
+    if (secondSiteId) {
+      /**
+       * NOTE: check this link to see all the available options
+       * https://www.npmjs.com/package/@datapunt/matomo-tracker-react
+       */
+      _matomo.instance2 = createInstance({
+        secondUrlBase,
+        secondSiteId,
+        secondUserId,
+        secondTrackerUrl,
+        secondSrcUrl,
+        // Add your own configuration
+        ...(config.settings.matomo || {}),
+      });
     }
   }
 
-  if (_matomo.instance) fn(_matomo.instance);
+  if (_matomo.instance1) fn(_matomo.instance1);
+  if (_matomo.instance2) fn(_matomo.instance2);
 };
 
 export const trackPageView = ({ href, ...options }) => {


### PR DESCRIPTION
This helps when you have subsites and want to track all traffic to main domain like:
* www.eea.europa.eu
* But you want to also track separately subsite traffic like:
* www.eea.europa.eu/ims