### PR TITLE
Track query params

### DIFF
--- a/src/MatomoAppExtra.jsx
+++ b/src/MatomoAppExtra.jsx
@@ -5,6 +5,7 @@ import { trackPageView } from './utils';
 export const MatomoAppExtra = ({ location, content }) => {
   const title = content?.title;
   const pathname = location.pathname.replace(/\/$/, '');
+  const query = location?.search ?? '';
 
   const href = flattenToAppURL(content?.['@id'] || '');
   const baseUrl = getBaseUrl(pathname) || '';
@@ -12,14 +13,14 @@ export const MatomoAppExtra = ({ location, content }) => {
   React.useEffect(() => {
     if (href === pathname) {
       // a document (content)
-      trackPageView({ href, documentTitle: title });
+      trackPageView({ href: href.concat(query), documentTitle: title });
     }
     if (baseUrl !== pathname) {
       // a route (utility view)
       const action = pathname.split('/')[pathname.split('/').length - 1];
-      trackPageView({ href: pathname, documentTitle: action });
+      trackPageView({ href: pathname.concat(query), documentTitle: action });
     }
-  }, [href, pathname, title, baseUrl]);
+  }, [href, pathname, title, baseUrl, query]);
 
   return <React.Fragment />;
 };

--- a/src/MatomoAppExtra.jsx
+++ b/src/MatomoAppExtra.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { flattenToAppURL, getBaseUrl } from '@plone/volto/helpers';
-import { trackPageView } from './utils';
+import { trackPageView, setCustomUrl } from './utils';
 
 export const MatomoAppExtra = ({ location, content }) => {
   const title = content?.title;
@@ -14,13 +14,15 @@ export const MatomoAppExtra = ({ location, content }) => {
     if (href === pathname) {
       // a document (content)
       trackPageView({ href: href + query, documentTitle: title });
+      setCustomUrl(window.location.pathname.substr(1) + location.search);
     }
     if (baseUrl !== pathname) {
       // a route (utility view)
       const action = pathname.split('/')[pathname.split('/').length - 1];
       trackPageView({ href: pathname + query, documentTitle: action });
+      setCustomUrl(window.location.pathname.substr(1) + location.search);
     }
-  }, [href, pathname, title, baseUrl, query]);
+  }, [href, pathname, title, baseUrl, query, location.search]);
 
   return <React.Fragment />;
 };

--- a/src/MatomoAppExtra.jsx
+++ b/src/MatomoAppExtra.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { flattenToAppURL, getBaseUrl } from '@plone/volto/helpers';
-import { trackPageView, setCustomUrl } from './utils';
+import { trackPageView } from './utils';
 
 export const MatomoAppExtra = ({ location, content }) => {
   const title = content?.title;
@@ -14,13 +14,11 @@ export const MatomoAppExtra = ({ location, content }) => {
     if (href === pathname) {
       // a document (content)
       trackPageView({ href: href + query, documentTitle: title });
-      setCustomUrl(window.location.pathname.substr(1) + location.search);
     }
     if (baseUrl !== pathname) {
       // a route (utility view)
       const action = pathname.split('/')[pathname.split('/').length - 1];
       trackPageView({ href: pathname + query, documentTitle: action });
-      setCustomUrl(window.location.pathname.substr(1) + location.search);
     }
   }, [href, pathname, title, baseUrl, query, location.search]);
 

--- a/src/MatomoAppExtra.jsx
+++ b/src/MatomoAppExtra.jsx
@@ -20,7 +20,7 @@ export const MatomoAppExtra = ({ location, content }) => {
       const action = pathname.split('/')[pathname.split('/').length - 1];
       trackPageView({ href: pathname + query, documentTitle: action });
     }
-  }, [href, pathname, title, baseUrl, query, location.search]);
+  }, [href, pathname, title, baseUrl, query]);
 
   return <React.Fragment />;
 };

--- a/src/MatomoAppExtra.jsx
+++ b/src/MatomoAppExtra.jsx
@@ -13,12 +13,12 @@ export const MatomoAppExtra = ({ location, content }) => {
   React.useEffect(() => {
     if (href === pathname) {
       // a document (content)
-      trackPageView({ href: href.concat(query), documentTitle: title });
+      trackPageView({ href: href + query, documentTitle: title });
     }
     if (baseUrl !== pathname) {
       // a route (utility view)
       const action = pathname.split('/')[pathname.split('/').length - 1];
-      trackPageView({ href: pathname.concat(query), documentTitle: action });
+      trackPageView({ href: pathname + query, documentTitle: action });
     }
   }, [href, pathname, title, baseUrl, query]);
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -91,6 +91,12 @@ export const trackPageView = ({ href, ...options }) => {
   });
 };
 
+export const setCustomUrl = (url) => {
+  doWithMatomo((m) => {
+    m.pushInstruction('setCustomUrl', url);
+  });
+};
+
 export const trackEvent = (options) => {
   doWithMatomo((m) => {
     m.trackEvent(options);


### PR DESCRIPTION
 I noticed campaigns URLs behave a bit differently than ordinary URLs being tracked. I didn't notice a real-time update of those params hit like how usual visitors are tracked. Maybe there's a different scenarios behind how matomo deals with query params.
 
<img width="593" alt="Screenshot 2023-07-12 at 11 36 06 PM" src="https://github.com/eea/volto-matomo/assets/22280901/de3772d8-3b8a-4a2e-9c82-b2af7b7b04fb">
